### PR TITLE
add GitHubOIDCConfig struct for user variables

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,14 +76,14 @@ pub struct GitHubClaims {
     pub iat: u64,
 }
 
+/// Default URL for fetching GitHub OIDC tokens
+pub const DEFAULT_GITHUB_OIDC_URL: &str = "https://token.actions.githubusercontent.com";
+
 /// Fetches the JSON Web Key Set (JWKS) from the specified OIDC URL.
-///
-/// This function is used to retrieve the set of public keys that GitHub uses
-/// to sign its JSON Web Tokens (JWTs).
 ///
 /// # Arguments
 ///
-/// * `oidc_url` - The base URL of the OpenID Connect provider (GitHub in this case)
+/// * `oidc_url` - The base URL of the OpenID Connect provider (GitHub by default)
 ///
 /// # Returns
 ///
@@ -93,12 +93,11 @@ pub struct GitHubClaims {
 /// # Example
 ///
 /// ```
-/// use github_oidc::fetch_jwks;
+/// use github_oidc::{fetch_jwks, DEFAULT_GITHUB_OIDC_URL};
 /// 
 /// #[tokio::main]
 /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let oidc_url = "https://token.actions.githubusercontent.com";
-///     let jwks = fetch_jwks(oidc_url).await?;
+///     let jwks = fetch_jwks(DEFAULT_GITHUB_OIDC_URL).await?;
 ///     println!("JWKS: {:?}", jwks);
 ///     Ok(())
 /// }
@@ -254,19 +253,17 @@ impl GithubJWKS {
 ///
 /// ```
 /// use std::sync::Arc;
-/// use github_oidc::{GithubJWKS, validate_github_token, fetch_jwks, GitHubOIDCConfig};
+/// use github_oidc::{GithubJWKS, validate_github_token, fetch_jwks, GitHubOIDCConfig, DEFAULT_GITHUB_OIDC_URL};
 /// use tokio::sync::RwLock;
 ///
 /// #[tokio::main]
 /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let oidc_url = "https://token.actions.githubusercontent.com";
-///     let jwks = fetch_jwks(oidc_url).await?;
+///     let jwks = Arc::new(RwLock::new(fetch_jwks(DEFAULT_GITHUB_OIDC_URL).await?));
 ///     
 ///     let config = GitHubOIDCConfig {
-/// 
-///         audience: Some("https://github.com/seif-mamdouh".to_string()),
-///         repository: Some("seif-mamdouh/your-repo".to_string()),
-///         repository_owner: Some("seif-mamdouh".to_string()),
+///         audience: Some("https://github.com/user-name".to_string()),
+///         repository: Some("user-name/repo".to_string()),
+///         repository_owner: Some("user-name".to_string()),
 ///     };
 ///
 ///     let token = "your_github_oidc_token_here";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,15 @@ pub struct GitHubClaims {
 /// # Example
 ///
 /// ```
-/// let jwks = fetch_jwks(your_oidc_url).await?;
+/// use github_oidc::fetch_jwks;
+/// 
+/// #[tokio::main]
+/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let oidc_url = "https://token.actions.githubusercontent.com";
+///     let jwks = fetch_jwks(oidc_url).await?;
+///     println!("JWKS: {:?}", jwks);
+///     Ok(())
+/// }
 /// ```
 pub async fn fetch_jwks(oidc_url: &str) -> Result<GithubJWKS, GitHubOIDCError> {
     info!("Fetching JWKS from {}", oidc_url);
@@ -252,12 +260,13 @@ impl GithubJWKS {
 /// #[tokio::main]
 /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let oidc_url = "https://token.actions.githubusercontent.com";
-///     let jwks = Arc::new(RwLock::new(fetch_jwks(oidc_url).await?));
+///     let jwks = fetch_jwks(oidc_url).await?;
 ///     
 ///     let config = GitHubOIDCConfig {
-///         audience: Some("https://github.com/your-username".to_string()),
-///         repository: Some("your-username/your-repo".to_string()),
-///         repository_owner: Some("your-username".to_string()),
+/// 
+///         audience: Some("https://github.com/seif-mamdouh".to_string()),
+///         repository: Some("seif-mamdouh/your-repo".to_string()),
+///         repository_owner: Some("seif-mamdouh".to_string()),
 ///     };
 ///
 ///     let token = "your_github_oidc_token_here";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ pub async fn fetch_jwks(oidc_url: &str) -> Result<GithubJWKS, GitHubOIDCError> {
 }
 
 /// Configuration options for GitHub OIDC token validation
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct GitHubOIDCConfig {
     /// Expected audience for the token
     pub audience: Option<String>,
@@ -126,16 +126,6 @@ pub struct GitHubOIDCConfig {
     pub repository: Option<String>,
     /// Expected repository owner for the token
     pub repository_owner: Option<String>,
-}
-
-impl Default for GitHubOIDCConfig {
-    fn default() -> Self {
-        Self {
-            audience: None,
-            repository: None,
-            repository_owner: None,
-        }
-    }
 }
 
 impl GithubJWKS {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ pub const DEFAULT_GITHUB_OIDC_URL: &str = "https://token.actions.githubuserconte
 ///
 /// ```
 /// use github_oidc::{fetch_jwks, DEFAULT_GITHUB_OIDC_URL};
-/// 
+///
 /// #[tokio::main]
 /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let jwks = fetch_jwks(DEFAULT_GITHUB_OIDC_URL).await?;


### PR DESCRIPTION
## Description
This PR introduces a new `GitHubOIDCConfig` struct, allowing for more flexible way for user to add env variables via a struct.

## Key Changes
- Added `GitHubOIDCConfig` struct with optional fields for audience, repository, and repository owner
- Updated `validate_github_token` function to accept the new config struct
- Removed environment variable dependencies for validation
- Updated documentation and examples to reflect new usage

## Usage Example
```rust
let config = GitHubOIDCConfig {
audience: Some("https://github.com/your-username".to_string()),
repository: Some("your-username/your-repo".to_string()),
repository_owner: Some("your-username".to_string()),
};
let result = validate_github_token(token, jwks, &config).await;
```