### PR TITLE
Change subject to sub in the claims

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub struct GithubJWKS {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GitHubClaims {
     /// The subject of the token (e.g the GitHub Actions runner ID).
-    pub subject: String,
+    pub sub: String,
 
     /// The full name of the repository.
     pub repository: String,


### PR DESCRIPTION
The documentation for this token is here: https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect#understanding-the-oidc-token

The subject field in JWTs is typically abbreviated `sub` and Github follows this pattern here

With this commit I was able to verify my OIDC Token from Github and successfully automate my screenshots! 🎉 