### PR TITLE
Make Error type public to crate users

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,7 @@
 use thiserror::Error;
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum GitHubOIDCError {
     #[error("Invalid token format. Expected a JWT.")]
     InvalidTokenFormat,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 mod errors;
-use errors::GitHubOIDCError;
+pub use errors::GitHubOIDCError;
 use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
@@ -58,7 +58,7 @@ pub struct GithubJWKS {
 /// This struct helps decode and access the information from that token.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GitHubClaims {
-    /// The subject of the token (e.g the GitHub Actions runner ID).
+    /// The subject of the token (e.g. the GitHub Actions runner ID).
     pub sub: String,
 
     /// The full name of the repository.


### PR DESCRIPTION
This makes the `Error` type public so it can be matched on by consumers. I also made it `non_exhaustive` so that it doesn't break on variant additions.